### PR TITLE
这个ProgressHeigt是一个NSNumber

### DIFF
--- a/HJProgressView/Class/UIProgressView+Radius.m
+++ b/HJProgressView/Class/UIProgressView+Radius.m
@@ -17,7 +17,7 @@
     if (self.superview) {
         [self addConstraintWithHeigt:progressHeigt];
     }
-    objc_setAssociatedObject(self, @selector(progressHeigt), @(progressHeigt), OBJC_ASSOCIATION_ASSIGN);
+    objc_setAssociatedObject(self, @selector(progressHeigt), @(progressHeigt), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
    
 }
 


### PR DESCRIPTION
这个ProgressHeigt是一个NSNumber，应该使用 OBJC_ASSOCIATION_RETAIN_NONATOMIC，而不是 OBJC_ASSOCIATION_ASSIGN 。会导致ProgressHeigt提前释放，崩溃